### PR TITLE
Adding device token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 Flutter plugin to support iOS and Android Sources at https://segment.com.
 
-#Example
+# Example
 
-1. Import flutter-segment 
-2. Setup your Android and iOS Sources as described at Segment.com and generate your write keys  
+1. Import flutter-segment
+2. Setup your Android and iOS Sources as described at Segment.com and generate your write keys
 3. Android: Add your write key to AndroidManifest Meta Data:
-```
+```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.flutter_segment_example">
 
@@ -44,7 +44,7 @@ Flutter plugin to support iOS and Android Sources at https://segment.com.
 </manifest>
 ```
 4. iOS: Add your write key to Info.plist
-```
+```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -95,14 +95,35 @@ Flutter plugin to support iOS and Android Sources at https://segment.com.
 ```
 5. Start tracking events
 
-```
+```dart
 FlutterSegment.track(
                 eventName: 'TestEvent',
                 properties: {
                   'price': 12.22,
                   'product': 'TestProduct',
                 },
-              );           
+              );
+```
+
+# Sending device tokens for push notifications
+
+Segment integrates with 3rd parties that allow sending push notifications.
+In order to do that you will need to provide it with the device token - which can be obtained using one of the several Flutter libraries.
+
+As soon as you obtain the device token, you need to add it to Segment's context and then emit a tracking event named `Application Opened` or `Application Installed`. The tracking event is needed because it is the [only moment when Segment propagates it to 3rd parties](https://segment.com/docs/connections/destinations/catalog/customer-io/).
+
+Both calls (`putDeviceToken` and `track`) can be done sequentially at startup time, given that the token exists.
+Nonetheless, if you don't want to delay the token propagation and don't mind having an extra `Application Opened` event in the middle of your app's events, it can be done right away when the token is acquired.
+
+```dart
+await FlutterSegment.putDeviceToken(token);
+/// the token is only propagated when one of two events are called:
+/// - Application Installed
+/// - Application Opened
+///
+await FlutterSegment.track(
+	eventName: 'Application Opened'
+);
 ```
 
 ## Getting Started
@@ -112,6 +133,6 @@ This project is a starting point for a Flutter
 a specialized package that includes platform-specific implementation code for
 Android and/or iOS.
 
-For help getting started with Flutter, view our 
-[online documentation](https://flutter.dev/docs), which offers tutorials, 
+For help getting started with Flutter, view our
+[online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.

--- a/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
+++ b/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.util.Log;
 
 import com.segment.analytics.Analytics;
+import com.segment.analytics.AnalyticsContext;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
 
@@ -65,6 +66,8 @@ public class FlutterSegmentPlugin implements MethodCallHandler {
       this.anonymousId(result);
     } else if (call.method.equals("reset")) {
       this.reset(result);
+    } else if (call.method.equals("putDeviceToken")) {
+      this.putDeviceToken(call, result);
     } else {
       result.notImplemented();
     }
@@ -184,6 +187,17 @@ public class FlutterSegmentPlugin implements MethodCallHandler {
   private void reset(Result result) {
     try {
       Analytics.with(this.context).reset();
+      result.success(true);
+    } catch (Exception e) {
+      result.error("FlutterSegmentException", e.getLocalizedMessage(), null);
+    }
+  }
+
+  private void putDeviceToken(MethodCall call, Result result) {
+    try {
+      String token = call.argument("token");
+      AnalyticsContext analyticsContext = Analytics.with(context).getAnalyticsContext();
+      analyticsContext.putDeviceToken(token);
       result.success(true);
     } catch (Exception e) {
       result.error("FlutterSegmentException", e.getLocalizedMessage(), null);

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -42,6 +42,8 @@
         [self enable:result];
     } else if ([@"debug" isEqualToString:call.method]) {
         [self debug:call result:result];
+    } else if ([@"putDeviceToken" isEqualToString:call.method]) {
+        [self putDeviceToken:call result:result];
     } else {
         result(FlutterMethodNotImplemented);
     }
@@ -164,6 +166,19 @@
     @try {
         BOOL enabled = call.arguments[@"debug"];
         [SEGAnalytics debug: enabled];
+        result([NSNumber numberWithBool:YES]);
+    }
+    @catch (NSException *exception) {
+        result([FlutterError errorWithCode:@"FlutterSegmentException" message:[exception reason] details: nil]);
+    }
+}
+
+
+- (void)putDeviceToken:(FlutterMethodCall*)call result:(FlutterResult)result {
+    @try {
+        NSString *token = call.arguments[@"token"];
+        NSData* data = [token dataUsingEncoding:NSUTF8StringEncoding];
+        [[SEGAnalytics sharedAnalytics] registeredForRemoteNotificationsWithDeviceToken: data];
         result([NSNumber numberWithBool:YES]);
     }
     @catch (NSException *exception) {

--- a/lib/flutter_segment.dart
+++ b/lib/flutter_segment.dart
@@ -102,6 +102,16 @@ class FlutterSegment {
       print(exception);
     }
   }
+
+  static Future<void> putDeviceToken(String token) async {
+    try {
+      await _channel.invokeMethod('putDeviceToken', {
+        "token": token,
+      });
+    } on PlatformException catch (exception) {
+      print(exception);
+    }
+  }
 }
 
 typedef String ScreenNameExtractor(RouteSettings settings);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,10 @@
 name: flutter_segment
 description: Flutter implementation of Segment Analytics for iOS and Android.
-version: 0.0.5
-author: Kevin Luecke <kevin@claimsforce.com>
-homepage: https://www.claimsforce.com
+version: 0.0.6
+authors:
+  - Kevin Luecke <kevin@claimsforce.com>
+  - Vinicius Zani <vinicius@queroanimo.com>
+homepage: https://github.com/claimsforce-gmbh/flutter-segment
 
 environment:
   sdk: ">=2.1.0 <3.0.0"


### PR DESCRIPTION
Adding support to set device token.

Segment sends tokens along with tracking events (`Application Opened` and `Application Installed` only), in the context field.

Tested on Android (emulator, device) and iOS 13.x (emulator, device).