### PR TITLE
Fixing MissingPluginException on Android

### DIFF
--- a/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
+++ b/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
@@ -105,6 +105,9 @@ public class FlutterSegmentPlugin implements MethodCallHandler, FlutterPlugin {
   }
 
   @Override
+  public void onDetachedFromEngine(FlutterPluginBinding binding) { }
+
+  @Override
   public void onMethodCall(MethodCall call, Result result) {
     if(call.method.equals("identify")) {
       this.identify(call, result);


### PR DESCRIPTION
This PR fixes #6.

Since Analytics uses a singleton to operate, calling `Analytics.setSingletonInstance` throws an exception when already registered ([see here](https://github.com/segmentio/analytics-android/blob/master/analytics/src/main/java/com/segment/analytics/Analytics.java#L197)).

This may happen on Android when you _exit_ the app tapping the back button and then open the app again from the TaskManager. In this case you're technically re-attaching the plugin to the engine (`onAttachedToEngine`).