### PR TITLE
Add protection for using package with add-to-app 

### DIFF
--- a/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
+++ b/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
@@ -57,6 +57,12 @@ public class FlutterSegmentPlugin implements MethodCallHandler, FlutterPlugin {
       Bundle bundle = ai.metaData;
       String writeKey = bundle.getString("com.claimsforce.segment.WRITE_KEY");
       Boolean trackApplicationLifecycleEvents = bundle.getBoolean("com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS");
+
+      // Do not execute if there is no write key
+      if (writeKey == null) {
+        return;
+      }
+
       Analytics.Builder analyticsBuilder = new Analytics.Builder(applicationContext, writeKey);
       if (trackApplicationLifecycleEvents) {
         // Enable this to record certain application events automatically

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -9,10 +9,22 @@ static NSDictionary *_appendToContextMiddleware;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   @try {
+    FlutterMethodChannel* channel = [FlutterMethodChannel
+                                    methodChannelWithName:@"flutter_segment"
+                                    binaryMessenger:[registrar messenger]];
+    FlutterSegmentPlugin* instance = [[FlutterSegmentPlugin alloc] init];
+    [registrar addMethodCallDelegate:instance channel:channel];
+
     NSString *path = [[NSBundle mainBundle] pathForResource: @"Info" ofType: @"plist"];
     NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile: path];
     NSString *writeKey = [dict objectForKey: @"com.claimsforce.segment.WRITE_KEY"];
     BOOL trackApplicationLifecycleEvents = [[dict objectForKey: @"com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS"] boolValue];
+
+    // Do not execute if there is no write key
+    if(writeKey == nil) {
+        return;
+    }
+
     SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:writeKey];
 
     // This middleware is responsible for manipulating only the context part of the request,
@@ -101,11 +113,6 @@ static NSDictionary *_appendToContextMiddleware;
 
     configuration.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents;
     [SEGAnalytics setupWithConfiguration:configuration];
-    FlutterMethodChannel* channel = [FlutterMethodChannel
-      methodChannelWithName:@"flutter_segment"
-      binaryMessenger:[registrar messenger]];
-    FlutterSegmentPlugin* instance = [[FlutterSegmentPlugin alloc] init];
-    [registrar addMethodCallDelegate:instance channel:channel];
   }
   @catch (NSException *exception) {
     NSLog(@"%@", [exception reason]);


### PR DESCRIPTION
## PR description:

This pr:
- moves the method channel creation to the first action when attaching to the flutter engine for both iOS and Android
- adds a guard against a null write key on both platforms.  A null write key can occur when using add-to-app and running a flutter module in standalone mode.  Write keys are taken from the native code and therefore not present in standalone mode