### PR TITLE
Installation via Dart Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,25 @@ Setup your Android, iOS and/or web sources as described at Segment.com and gener
 Set your Segment write key and change the automatic event tracking (only for Android and iOS) on if you wish the library to take care of it for you.
 Remember that the application lifecycle events won't have any special context set for you by the time it is initialized.
 
-### Android`
+### Via Dart Code
+```dart
+void main() {
+  /// Wait until the platform channel is properly initialized so we can call
+  /// `setContext` during the app initialization.
+  WidgetsFlutterBinding.ensureInitialized();
+
+  Segment.config(
+    options: SegmentConfig(
+      writeKey: 'YOUR_WRITE_KEY_GOES_HERE',
+      trackApplicationLifecycleEvents: false,
+      amplitudeIntegrationEnabled: false,
+      debug: false,
+    ),
+  );
+}
+```
+
+### Android _(Deprecated*)_
 ```xml
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.flutter_segment_example">
     <application>
@@ -96,7 +114,7 @@ Remember that the application lifecycle events won't have any special context se
 </manifest>
 ```
 
-### iOS
+### iOS _(Deprecated*)_
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -208,3 +226,5 @@ Please file any issues, bugs, or feature requests in the [GitHub repo](https://g
 
 ## Contributing
 If you wish to contribute a change to this repo, please send a [pull request](https://github.com/claimsforce-gmbh/flutter-segment/pulls).
+
+_<sup>*</sup>This installation method will be removed, please use the [Installation via Dart Code](#via-dart-code) instructions._

--- a/android/src/main/java/com/example/flutter_segment/FlutterSegmentOptions.java
+++ b/android/src/main/java/com/example/flutter_segment/FlutterSegmentOptions.java
@@ -1,0 +1,55 @@
+package com.example.flutter_segment;
+
+import android.os.Bundle;
+
+import java.util.HashMap;
+
+public class FlutterSegmentOptions {
+    private final String writeKey;
+    private final Boolean trackApplicationLifecycleEvents;
+    private final Boolean amplitudeIntegrationEnabled;
+    private final Boolean debug;
+
+    public  FlutterSegmentOptions(String writeKey, Boolean trackApplicationLifecycleEvents, Boolean amplitudeIntegrationEnabled, Boolean debug) {
+        this.writeKey = writeKey;
+        this.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents;
+        this.amplitudeIntegrationEnabled = amplitudeIntegrationEnabled;
+        this.debug = debug;
+    }
+
+    public String getWriteKey() {
+        return writeKey;
+    }
+
+    public Boolean getTrackApplicationLifecycleEvents() {
+        return trackApplicationLifecycleEvents;
+    }
+
+    public Boolean isAmplitudeIntegrationEnabled() {
+        return amplitudeIntegrationEnabled;
+    }
+
+    public Boolean getDebug() {
+        return debug;
+    }
+
+    static FlutterSegmentOptions create(Bundle bundle) {
+        String writeKey = bundle.getString("com.claimsforce.segment.WRITE_KEY");
+        Boolean trackApplicationLifecycleEvents = bundle.getBoolean("com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS");
+        Boolean isAmplitudeIntegrationEnabled = bundle.getBoolean("com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION", false);
+        Boolean debug = bundle.getBoolean("com.claimsforce.segment.DEBUG", false);
+        return new FlutterSegmentOptions(writeKey, trackApplicationLifecycleEvents, isAmplitudeIntegrationEnabled, debug);
+    }
+
+    static FlutterSegmentOptions create(HashMap<String, Object> options) {
+        String writeKey = (String) options.get("writeKey");
+        Boolean trackApplicationLifecycleEvents = (Boolean) options.get("trackApplicationLifecycleEvents");
+        Boolean isAmplitudeIntegrationEnabled = orFalse((Boolean) options.get("amplitudeIntegrationEnabled"));
+        Boolean debug = orFalse((Boolean) options.get("debug"));
+        return new FlutterSegmentOptions(writeKey, trackApplicationLifecycleEvents, isAmplitudeIntegrationEnabled, debug);
+    }
+
+    private static Boolean orFalse(Boolean value) {
+        return value == null ? false : value;
+    }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,6 +8,13 @@ void main() {
   /// `setContext` during the app initialization.
   WidgetsFlutterBinding.ensureInitialized();
 
+  Segment.config(
+    options: SegmentConfig(
+        writeKey: 'YOUR_WRITE_KEY_GOES_HERE',
+        trackApplicationLifecycleEvents: false,
+    ),
+  );
+
   /// The `context.device.token` is a special property.
   /// When you define it, setting the context again with no token property (ex: `{}`)
   /// has no effect on cleaning up the device token.
@@ -100,13 +107,13 @@ class MyApp extends StatelessWidget {
             Spacer(),
             Platform.isIOS
                 ? Center(
-                    child: FlatButton(
-                      child: Text('Debug mode'),
-                      onPressed: () {
-                        Segment.debug(true);
-                      },
-                    ),
-                  )
+              child: FlatButton(
+                child: Text('Debug mode'),
+                onPressed: () {
+                  Segment.debug(true);
+                },
+              ),
+            )
                 : Container(),
             Spacer(),
           ],

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -9,118 +9,113 @@
 static NSDictionary *_appendToContextMiddleware;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
-  @try {
-    NSString *path = [[NSBundle mainBundle] pathForResource: @"Info" ofType: @"plist"];
-    NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile: path];
-    NSString *writeKey = [dict objectForKey: @"com.claimsforce.segment.WRITE_KEY"];
-    BOOL trackApplicationLifecycleEvents = [[dict objectForKey: @"com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS"] boolValue];
-    BOOL isAmplitudeIntegrationEnabled = [[dict objectForKey: @"com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION"] boolValue];
-    SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:writeKey];
-
-    // This middleware is responsible for manipulating only the context part of the request,
-    // leaving all other fields as is.
-    SEGMiddlewareBlock contextMiddleware = ^(SEGContext *_Nonnull context, SEGMiddlewareNext _Nonnull next) {
-      // Do not execute if there is nothing to append
-      if (_appendToContextMiddleware == nil) {
-        next(context);
-        return;
-      }
-
-      // Avoid overriding the context if there is none to override
-      // (see different payload types here: https://github.com/segmentio/analytics-ios/tree/master/Analytics/Classes/Integrations)
-      if (![context.payload isKindOfClass:[SEGTrackPayload class]]
-        && ![context.payload isKindOfClass:[SEGScreenPayload class]]
-        && ![context.payload isKindOfClass:[SEGGroupPayload class]]
-        && ![context.payload isKindOfClass:[SEGIdentifyPayload class]]) {
-        next(context);
-        return;
-      }
-
-      next([context
-        modify: ^(id<SEGMutableContext> _Nonnull ctx) {
-          if (_appendToContextMiddleware == nil) {
-            return;
-          }
-
-          // do not touch it if no payload is present
-          if (ctx.payload == nil) {
-            NSLog(@"Cannot update segment context when the current context payload is empty.");
-            return;
-          }
-
-          @try {
-            // We need to perform a deep merge to not lose any sub-dictionary
-            // that is already set. [contextToAppend] has precedence over [ctx.payload.context] values
-            NSDictionary *combinedContext = [FlutterSegmentPlugin
-              mergeDictionary: ctx.payload.context == nil
-                ? [[NSDictionary alloc] init]
-                : [ctx.payload.context copy]
-              with: _appendToContextMiddleware];
-
-            // SEGPayload does not offer copyWith* methods, so we have to
-            // manually test and re-create it for each of its type.
-            if ([ctx.payload isKindOfClass:[SEGTrackPayload class]]) {
-              ctx.payload = [[SEGTrackPayload alloc]
-                initWithEvent: ((SEGTrackPayload*)ctx.payload).event
-                properties: ((SEGTrackPayload*)ctx.payload).properties
-                context: combinedContext
-                integrations: ((SEGTrackPayload*)ctx.payload).integrations
-              ];
-            } else if ([ctx.payload isKindOfClass:[SEGScreenPayload class]]) {
-              ctx.payload = [[SEGScreenPayload alloc]
-                initWithName: ((SEGScreenPayload*)ctx.payload).name
-                properties: ((SEGScreenPayload*)ctx.payload).properties
-                context: combinedContext
-                integrations: ((SEGScreenPayload*)ctx.payload).integrations
-              ];
-            } else if ([ctx.payload isKindOfClass:[SEGGroupPayload class]]) {
-              ctx.payload = [[SEGGroupPayload alloc]
-                initWithGroupId: ((SEGGroupPayload*)ctx.payload).groupId
-                traits: ((SEGGroupPayload*)ctx.payload).traits
-                context: combinedContext
-                integrations: ((SEGGroupPayload*)ctx.payload).integrations
-              ];
-            } else if ([ctx.payload isKindOfClass:[SEGIdentifyPayload class]]) {
-              ctx.payload = [[SEGIdentifyPayload alloc]
-                initWithUserId: ((SEGIdentifyPayload*)ctx.payload).userId
-                anonymousId: ((SEGIdentifyPayload*)ctx.payload).anonymousId
-                traits: ((SEGIdentifyPayload*)ctx.payload).traits
-                context: combinedContext
-                integrations: ((SEGIdentifyPayload*)ctx.payload).integrations
-              ];
-            }
-          }
-          @catch (NSException *exception) {
-            NSLog(@"Could not update segment context: %@", [exception reason]);
-          }
-        }]
-      );
-    };
-
-    configuration.middlewares = @[
-      [[SEGBlockMiddleware alloc] initWithBlock:contextMiddleware]
-    ];
-
-    configuration.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents;
-
-    if (isAmplitudeIntegrationEnabled) {
-      [configuration use:[SEGAmplitudeIntegrationFactory instance]];
-    }
-
-    [SEGAnalytics setupWithConfiguration:configuration];
     FlutterMethodChannel* channel = [FlutterMethodChannel
       methodChannelWithName:@"flutter_segment"
       binaryMessenger:[registrar messenger]];
     FlutterSegmentPlugin* instance = [[FlutterSegmentPlugin alloc] init];
+    
+    SEGAnalyticsConfiguration *configuration = [FlutterSegmentPlugin createConfigFromFile];
+    [instance setup:configuration];
+    
     [registrar addMethodCallDelegate:instance channel:channel];
-  }
-  @catch (NSException *exception) {
-    NSLog(@"%@", [exception reason]);
-  }
+}
+
+- (void)setup:(SEGAnalyticsConfiguration*) configuration  {
+    @try {
+        // This middleware is responsible for manipulating only the context part of the request,
+        // leaving all other fields as is.
+        SEGMiddlewareBlock contextMiddleware = ^(SEGContext *_Nonnull context, SEGMiddlewareNext _Nonnull next) {
+          // Do not execute if there is nothing to append
+          if (_appendToContextMiddleware == nil) {
+            next(context);
+            return;
+          }
+
+          // Avoid overriding the context if there is none to override
+          // (see different payload types here: https://github.com/segmentio/analytics-ios/tree/master/Analytics/Classes/Integrations)
+          if (![context.payload isKindOfClass:[SEGTrackPayload class]]
+            && ![context.payload isKindOfClass:[SEGScreenPayload class]]
+            && ![context.payload isKindOfClass:[SEGGroupPayload class]]
+            && ![context.payload isKindOfClass:[SEGIdentifyPayload class]]) {
+            next(context);
+            return;
+          }
+
+          next([context
+            modify: ^(id<SEGMutableContext> _Nonnull ctx) {
+              if (_appendToContextMiddleware == nil) {
+                return;
+              }
+
+              // do not touch it if no payload is present
+              if (ctx.payload == nil) {
+                NSLog(@"Cannot update segment context when the current context payload is empty.");
+                return;
+              }
+
+              @try {
+                // We need to perform a deep merge to not lose any sub-dictionary
+                // that is already set. [contextToAppend] has precedence over [ctx.payload.context] values
+                NSDictionary *combinedContext = [FlutterSegmentPlugin
+                  mergeDictionary: ctx.payload.context == nil
+                    ? [[NSDictionary alloc] init]
+                    : [ctx.payload.context copy]
+                  with: _appendToContextMiddleware];
+
+                // SEGPayload does not offer copyWith* methods, so we have to
+                // manually test and re-create it for each of its type.
+                if ([ctx.payload isKindOfClass:[SEGTrackPayload class]]) {
+                  ctx.payload = [[SEGTrackPayload alloc]
+                    initWithEvent: ((SEGTrackPayload*)ctx.payload).event
+                    properties: ((SEGTrackPayload*)ctx.payload).properties
+                    context: combinedContext
+                    integrations: ((SEGTrackPayload*)ctx.payload).integrations
+                  ];
+                } else if ([ctx.payload isKindOfClass:[SEGScreenPayload class]]) {
+                  ctx.payload = [[SEGScreenPayload alloc]
+                    initWithName: ((SEGScreenPayload*)ctx.payload).name
+                    properties: ((SEGScreenPayload*)ctx.payload).properties
+                    context: combinedContext
+                    integrations: ((SEGScreenPayload*)ctx.payload).integrations
+                  ];
+                } else if ([ctx.payload isKindOfClass:[SEGGroupPayload class]]) {
+                  ctx.payload = [[SEGGroupPayload alloc]
+                    initWithGroupId: ((SEGGroupPayload*)ctx.payload).groupId
+                    traits: ((SEGGroupPayload*)ctx.payload).traits
+                    context: combinedContext
+                    integrations: ((SEGGroupPayload*)ctx.payload).integrations
+                  ];
+                } else if ([ctx.payload isKindOfClass:[SEGIdentifyPayload class]]) {
+                  ctx.payload = [[SEGIdentifyPayload alloc]
+                    initWithUserId: ((SEGIdentifyPayload*)ctx.payload).userId
+                    anonymousId: ((SEGIdentifyPayload*)ctx.payload).anonymousId
+                    traits: ((SEGIdentifyPayload*)ctx.payload).traits
+                    context: combinedContext
+                    integrations: ((SEGIdentifyPayload*)ctx.payload).integrations
+                  ];
+                }
+              }
+              @catch (NSException *exception) {
+                NSLog(@"Could not update segment context: %@", [exception reason]);
+              }
+            }]
+          );
+        };
+        
+        configuration.middlewares = @[
+          [[SEGBlockMiddleware alloc] initWithBlock:contextMiddleware]
+        ];
+        [SEGAnalytics setupWithConfiguration:configuration];
+    }
+    @catch (NSException *exception) {
+      NSLog(@"%@", [exception reason]);
+    }
 }
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
-  if ([@"identify" isEqualToString:call.method]) {
+  if ([@"config" isEqualToString:call.method]) {
+    [self config:call result:result];
+  } else if ([@"identify" isEqualToString:call.method]) {
     [self identify:call result:result];
   } else if ([@"track" isEqualToString:call.method]) {
     [self track:call result:result];
@@ -145,6 +140,22 @@ static NSDictionary *_appendToContextMiddleware;
   } else {
     result(FlutterMethodNotImplemented);
   }
+}
+
+- (void)config:(FlutterMethodCall*)call result:(FlutterResult)result {
+  @try {
+    NSDictionary *options = call.arguments[@"options"];
+    SEGAnalyticsConfiguration *configuration = [FlutterSegmentPlugin createConfigFromDict:options];
+    [self setup:configuration];
+    result([NSNumber numberWithBool:YES]);
+  }
+  @catch (NSException *exception) {
+    result([FlutterError
+      errorWithCode:@"FlutterSegmentException"
+      message:[exception reason]
+      details: nil]);
+  }
+
 }
 
 - (void)setContext:(FlutterMethodCall*)call result:(FlutterResult)result {
@@ -287,6 +298,34 @@ static NSDictionary *_appendToContextMiddleware;
   @catch (NSException *exception) {
     result([FlutterError errorWithCode:@"FlutterSegmentException" message:[exception reason] details: nil]);
   }
+}
+
++ (SEGAnalyticsConfiguration*)createConfigFromFile {
+    NSString *path = [[NSBundle mainBundle] pathForResource: @"Info" ofType: @"plist"];
+    NSDictionary *dict = [NSDictionary dictionaryWithContentsOfFile: path];
+    NSString *writeKey = [dict objectForKey: @"com.claimsforce.segment.WRITE_KEY"];
+    BOOL trackApplicationLifecycleEvents = [[dict objectForKey: @"com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS"] boolValue];
+    BOOL isAmplitudeIntegrationEnabled = [[dict objectForKey: @"com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION"] boolValue];
+    SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:writeKey];
+    configuration.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents;
+
+    if (isAmplitudeIntegrationEnabled) {
+      [configuration use:[SEGAmplitudeIntegrationFactory instance]];
+    }
+    return configuration;
+}
+
++ (SEGAnalyticsConfiguration*)createConfigFromDict:(NSDictionary*) dict {
+    NSString *writeKey = [dict objectForKey: @"writeKey"];
+    BOOL trackApplicationLifecycleEvents = [[dict objectForKey: @"trackApplicationLifecycleEvents"] boolValue];
+    BOOL isAmplitudeIntegrationEnabled = [[dict objectForKey: @"amplitudeIntegrationEnabled"] boolValue];
+    SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:writeKey];
+    configuration.trackApplicationLifecycleEvents = trackApplicationLifecycleEvents;
+
+    if (isAmplitudeIntegrationEnabled) {
+      [configuration use:[SEGAmplitudeIntegrationFactory instance]];
+    }
+    return configuration;
 }
 
 + (NSDictionary *) mergeDictionary: (NSDictionary *) first with: (NSDictionary *) second {

--- a/lib/flutter_segment.dart
+++ b/lib/flutter_segment.dart
@@ -1,2 +1,3 @@
 export 'package:flutter_segment/src/segment.dart';
 export 'package:flutter_segment/src/segment_observer.dart';
+export 'package:flutter_segment/src/segment_config.dart';

--- a/lib/src/segment.dart
+++ b/lib/src/segment.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:flutter_segment/src/segment_default_options.dart';
+import 'package:flutter_segment/src/segment_config.dart';
 import 'package:flutter_segment/src/segment_platform_interface.dart';
 
 export 'package:flutter_segment/src/segment_observer.dart';
@@ -18,6 +20,14 @@ class Segment {
       userId: userId,
       traits: traits ?? {},
       options: options ?? SegmentDefaultOptions.instance.options ?? {},
+    );
+  }
+
+  static Future<void> config({
+    @required SegmentConfig options,
+  }) {
+    return _segment.config(
+      options: options,
     );
   }
 

--- a/lib/src/segment_config.dart
+++ b/lib/src/segment_config.dart
@@ -1,0 +1,22 @@
+class SegmentConfig {
+  final String writeKey;
+  final bool trackApplicationLifecycleEvents;
+  final bool amplitudeIntegrationEnabled;
+  final bool debug;
+
+  SegmentConfig({
+    this.writeKey,
+    this.trackApplicationLifecycleEvents,
+    this.amplitudeIntegrationEnabled = false,
+    this.debug = false,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'writeKey': writeKey,
+      'trackApplicationLifecycleEvents': trackApplicationLifecycleEvents,
+      'amplitudeIntegrationEnabled': amplitudeIntegrationEnabled,
+      'debug': debug,
+    };
+  }
+}

--- a/lib/src/segment_method_channel.dart
+++ b/lib/src/segment_method_channel.dart
@@ -1,9 +1,23 @@
 import 'package:flutter/services.dart';
+import 'package:flutter_segment/src/segment_config.dart';
+import 'package:flutter_segment/src/segment_default_options.dart';
 import 'package:flutter_segment/src/segment_platform_interface.dart';
 
 const MethodChannel _channel = MethodChannel('flutter_segment');
 
 class SegmentMethodChannel extends SegmentPlatform {
+  Future<void> config({
+    @required SegmentConfig options,
+  }) async {
+    try {
+      await _channel.invokeMethod('config', {
+        'options': options.toMap(),
+      });
+    } on PlatformException catch (exception) {
+      print(exception);
+    }
+  }
+
   Future<void> identify({
     String? userId,
     required Map<String, dynamic> traits,

--- a/lib/src/segment_platform_interface.dart
+++ b/lib/src/segment_platform_interface.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+import 'package:flutter_segment/src/segment_config.dart';
 import 'package:flutter_segment/src/segment_method_channel.dart';
 
 abstract class SegmentPlatform {
@@ -9,6 +11,12 @@ abstract class SegmentPlatform {
   ///
   /// Defaults to [SegmentMethodChannel]
   static SegmentPlatform instance = SegmentMethodChannel();
+
+  Future<void> config({
+    @required SegmentConfig options,
+  }) {
+    throw UnimplementedError('config() has not been implemented.');
+  }
 
   Future<void> identify({
     String? userId,


### PR DESCRIPTION
Allows the plugin to be configured (installed) via Dart Code, by exposing a `config` method in the Dart API which set's up the native library with the passed `SegmentConfig`.

The old functionality still works for compatibility reasons.

Fixes #22 