### PR TITLE
Make userId nullable for Identify (with Null Safety)

### DIFF
--- a/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
+++ b/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
@@ -168,7 +168,7 @@ public class FlutterSegmentPlugin implements MethodCallHandler, FlutterPlugin {
   }
 
   private void callIdentify(
-    String? userId,
+    String userId,
     HashMap<String, Object> traitsData,
     HashMap<String, Object> optionsData
   ) {

--- a/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
+++ b/android/src/main/java/com/example/flutter_segment/FlutterSegmentPlugin.java
@@ -168,7 +168,7 @@ public class FlutterSegmentPlugin implements MethodCallHandler, FlutterPlugin {
   }
 
   private void callIdentify(
-    String userId,
+    String? userId,
     HashMap<String, Object> traitsData,
     HashMap<String, Object> optionsData
   ) {

--- a/lib/src/segment.dart
+++ b/lib/src/segment.dart
@@ -10,7 +10,7 @@ class Segment {
   static SegmentPlatform get _segment => SegmentPlatform.instance;
 
   static Future<void> identify({
-    required userId,
+    String? userId,
     Map<String, dynamic>? traits,
     Map<String, dynamic>? options,
   }) {

--- a/lib/src/segment_method_channel.dart
+++ b/lib/src/segment_method_channel.dart
@@ -5,7 +5,7 @@ const MethodChannel _channel = MethodChannel('flutter_segment');
 
 class SegmentMethodChannel extends SegmentPlatform {
   Future<void> identify({
-    required userId,
+    String? userId,
     required Map<String, dynamic> traits,
     required Map<String, dynamic> options,
   }) async {

--- a/lib/src/segment_platform_interface.dart
+++ b/lib/src/segment_platform_interface.dart
@@ -11,7 +11,7 @@ abstract class SegmentPlatform {
   static SegmentPlatform instance = SegmentMethodChannel();
 
   Future<void> identify({
-    required userId,
+    String? userId,
     required Map<String, dynamic> traits,
     required Map<String, dynamic> options,
   }) {


### PR DESCRIPTION
This PR will allow the `userId` to be null on `identify`, the segment library for each platform allows it.

- Fix https://github.com/claimsforce-gmbh/flutter-segment/issues/58.
- Set the type for `userId` which should be an `String` always.

I added another branch before the Null Safety was merged to be able to use this if you have not migrated your app here: https://github.com/la-haus/flutter-library-segment/pull/1.