### PR TITLE
Fixes incorrect segment-amplitude header import on ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Remember that the application lifecycle events won't have any special context se
 	<key>com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS</key>
 	<false/>
 	<key>com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION</key>
-    <false/>
+  <false/>
 	[...]
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ Remember that the application lifecycle events won't have any special context se
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	[...]
-	<key>com.claimsforce.segment.WRITE_KEY</key>
-	<string>YOUR_WRITE_KEY_GOES_HERE</string>
-	<key>com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS</key>
-	<false/>
-	<key>com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION</key>
+  [...]
+  <key>com.claimsforce.segment.WRITE_KEY</key>
+  <string>YOUR_WRITE_KEY_GOES_HERE</string>
+  <key>com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS</key>
   <false/>
-	[...]
+  <key>com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION</key>
+  <false/>
+  [...]
 </dict>
 </plist>
 ```

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -2,7 +2,7 @@
 #import <Analytics/SEGAnalytics.h>
 #import <Analytics/SEGContext.h>
 #import <Analytics/SEGMiddleware.h>
-#import <Segment_Amplitude/SEGAmplitudeIntegrationFactory.h>
+#import <Segment-Amplitude/SEGAmplitudeIntegrationFactory.h>
 
 @implementation FlutterSegmentPlugin
 // Contents to be appended to the context


### PR DESCRIPTION
I started using this lib but it isn't functional on ios:
```
/Users/vagrant/.pub-cache/hosted/pub.dartlang.org/flutter_segment-3.1.2/ios/Classes/FlutterSegmentPlugin.m:5:9: fatal error: 'Segment_Amplitude/SEGAmplitudeIntegrationFactory.h' file not found
    #import <Segment_Amplitude/SEGAmplitudeIntegrationFactory.h>
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    1 error generated.
```

This import depends on `Segment-Amplitude` pod version `3.0.1`. According to their readme file, the valid import should be : [`#import <Segment-Amplitude/SEGAmplitudeIntegrationFactory.h>`](https://github.com/segment-integrations/analytics-ios-integration-amplitude/tree/3.0.1).

I found some closed PRs on this very repo trying to fix it but they were closed and I couldn't understand why. Also, some other people reported this problem as well:
https://github.com/claimsforce-gmbh/flutter-segment/issues/70
https://github.com/claimsforce-gmbh/flutter-segment/issues/68
https://github.com/claimsforce-gmbh/flutter-segment/issues/39

I would love to contribute to fixing this problem, after all this lib is of great help for me!