### PR TITLE
Revert "Fixes incorrect segment-amplitude header import on ios"

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,14 @@ void main() {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  [...]
-  <key>com.claimsforce.segment.WRITE_KEY</key>
-  <string>YOUR_WRITE_KEY_GOES_HERE</string>
-  <key>com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS</key>
-  <false/>
-  <key>com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION</key>
-  <false/>
-  [...]
+	[...]
+	<key>com.claimsforce.segment.WRITE_KEY</key>
+	<string>YOUR_WRITE_KEY_GOES_HERE</string>
+	<key>com.claimsforce.segment.TRACK_APPLICATION_LIFECYCLE_EVENTS</key>
+	<false/>
+	<key>com.claimsforce.segment.ENABLE_AMPLITUDE_INTEGRATION</key>
+    <false/>
+	[...]
 </dict>
 </plist>
 ```

--- a/ios/Classes/FlutterSegmentPlugin.m
+++ b/ios/Classes/FlutterSegmentPlugin.m
@@ -2,7 +2,7 @@
 #import <Analytics/SEGAnalytics.h>
 #import <Analytics/SEGContext.h>
 #import <Analytics/SEGMiddleware.h>
-#import <Segment-Amplitude/SEGAmplitudeIntegrationFactory.h>
+#import <Segment_Amplitude/SEGAmplitudeIntegrationFactory.h>
 
 @implementation FlutterSegmentPlugin
 // Contents to be appended to the context


### PR DESCRIPTION
Reverts claimsforce-gmbh/flutter-segment#72 due to compile error (see https://github.com/claimsforce-gmbh/flutter-segment/issues/75)