### PR TITLE
Set fixed flutter version on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'dev'
+          flutter-version: '2.0.0'
       - run: flutter pub get
       - run: flutter config --enable-web
       - run: flutter build web
@@ -41,7 +41,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'dev'
+          flutter-version: '2.0.0'
       - run: flutter pub get
       - run: flutter clean
       - run: flutter build ios --release --no-codesign
@@ -56,7 +56,7 @@ jobs:
           java-version: '12.x'
       - uses: subosito/flutter-action@v1
         with:
-          channel: 'dev'
+          flutter-version: '2.0.0'
       - run: flutter pub get
       - run: flutter build appbundle
 


### PR DESCRIPTION
This setup is not reproducible in the future and may break the CI flow in the future

I picked flutter version from https://github.com/claimsforce-gmbh/flutter-segment/blob/master/pubspec.yaml#L11, @MaiKaY is that ok?

# Current
We get whats in dev channel

# Expected
We get the flutter version that this project requires